### PR TITLE
Call the pygment highlighter on the whole input

### DIFF
--- a/colout.py
+++ b/colout.py
@@ -422,15 +422,7 @@ if __name__ == "__main__":
         else:
             formatter = TerminalFormatter()
 
-        while True:
-            try:
-                item = sys.stdin.readline()
-            except KeyboardInterrupt:
-                break
-            if not item:
-                break
-            colored = highlight(item, lexer, formatter)
-            write(colored)
+        write(highlight(sys.stdin.read(), lexer, formatter))
 
     # if color
     else:


### PR DESCRIPTION
I understand this patch might lead to some discussion. I would also prefer line-by-line processing from time to time.
However, I think multi-line strings or comments should be correctly highlighted by default.
