### PR TITLE
correctly detect a numeric color argument

### DIFF
--- a/colout.py
+++ b/colout.py
@@ -197,7 +197,7 @@ def colorin(text, color="red", style="normal"):
         color_code = str(30 + colors[color])
 
     # 256 colors mode
-    elif isinstance( color, int ):
+    elif color.isdigit():
         mode = 256
         color_nb = int(color)
         assert(0 <= color_nb <= 255)
@@ -220,6 +220,10 @@ def colorin(text, color="red", style="normal"):
             # We should return all but the last character,
             # because Pygments adds a newline char.
         return highlight(text, lexer, formatter)[:-1]
+
+    # unrecognized
+    else:
+        raise Exception('Unrecognized color %s' % color)
 
     return start + style_code + endmarks[mode] + color_code + "m" + text + stop
 


### PR DESCRIPTION
I tried the 256 colors example in the README and got an error because none of the if clauses in colorin() were triggering. I changed the test from `isinstance(color, int)` (which it isn't, it's a string) to `color.isdigit()` which seems to work better.
