### PR TITLE
fix IndexError during lexer collection

### DIFF
--- a/colout.py
+++ b/colout.py
@@ -89,7 +89,10 @@ except ImportError:
     pass
 else:
     for lexer in get_all_lexers():
-        lexers.append(lexer[1][0])
+        try:
+            lexers.append(lexer[1][0])
+        except IndexError:
+            pass
     lexers.sort()
 
 


### PR DESCRIPTION
I tried the 256 colors example in the README and got an error:

```
alex$ ./colout.py '/var/[a-z]+' 135 </etc/passwd
Traceback (most recent call last):
  File "./colout.py", line 92, in <module>
    lexers.append(lexer[1][0])
IndexError: tuple index out of range
```

It seems some of the lexers are just empty tuples. I added a try/catch block around that line.
