### PR TITLE
Pygments is not installed, can not use the“ ”-s python“

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.argv[-1] == 'publish':
 
 packages = ['colout']
 
-requires = []
+requires = ['pygments']
 
 setup(
     name='colout',


### PR DESCRIPTION
When not installed pygments error with:

Traceback (most recent call last):
  File "/usr/bin/colout", line 541, in <module>
    assert(pattern.lower() in lexers)
AssertionError
