### PR TITLE
README: remove non-ascii characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Don't use nested groups or colout will duplicate the corresponding input text wi
 * Color a make output, line numbers in yellow, errors in bold red, warning in magenta, pragma in green and C++ file base names in cyan:
   `make 2>&1 | colout ':([0-9]+):[0-9]*' yellow normal | colout error | colout warning magenta | colout pragma green normal | colout '/(\w+)*\.(h|cpp)' cyan normal`
   Or using themes:
-  `make 2>&³ | colout -t cmake | colout -t g++`
+  `make 2>&1 | colout -t cmake | colout -t g++`
 
 * Color each word in the head of auth.log with a rainbow color map, starting a new colormap at each new line (the
   beginning of the command is just bash magic to repeat the string "(\\w+)\\W+":


### PR DESCRIPTION
This prevented setup.py from working on my box:

```
Running setup.py egg_info for package from file:///mnt/ssd/src/3rdpart/colout-0.3
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/tmp/pip-8at8_o-build/setup.py", line 25, in <module>
        long_description=open('README.md').read(),
      File "/usr/lib/python3.3/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 7436: ordinal not in range
```
