### PR TITLE
Handle Unicode decode errors by continuing to process

### DIFF
--- a/colout/colout.py
+++ b/colout/colout.py
@@ -567,6 +567,8 @@ def map_write( stream_in, stream_out, function, *args ):
     while True:
         try:
             item = stream_in.readline()
+        except UnicodeDecodeError:
+            continue
         except KeyboardInterrupt:
             break
         if not item:


### PR DESCRIPTION
Used to result in an uncaught exception.
