### PR TITLE
Make cmake coloring work with Ninja

### DIFF
--- a/colout/colout.py
+++ b/colout/colout.py
@@ -367,6 +367,39 @@ def colorin(text, color="red", style="normal"):
             color = cmap[i]
             color_code = str(color)
 
+    elif color.lower() == "fraction": # "fraction" or "Fraction"
+
+        # get the different numbers in a list
+        nbs = re.split(r'[^0-9+.,e-]+', text)
+        nbs = [nb for nb in nbs if nb]
+
+        # interpret as decimal
+        try:
+            f = float(nbs[0])/float(nbs[1])
+        except Exception as e:
+            return text
+
+        # if out of scale, do not color
+        if f < 0 or f > 1:
+            return text
+
+        if color[0].islower():
+            mode = 8
+            cmap = colormaps["spectrum"]
+
+            # normalize and scale over the nb of colors in cmap
+            i = int( math.ceil( f * (len(cmap)-1) ) )
+
+            color = cmap[i]
+            color_code = str(30 + colors[color])
+
+        else:
+            mode = 256
+            cmap = colormaps["Spectrum"]
+            i = int( math.ceil( f * (len(cmap)-1) ) )
+            color = cmap[i]
+            color_code = str(color)
+
     # "hash" or "Hash"; useful to randomly but consistently color strings
     elif color.lower() == "hash":
         hasher = hashlib.md5()

--- a/colout/colout_cmake.py
+++ b/colout/colout_cmake.py
@@ -24,21 +24,26 @@ def theme():
         # Scan
         [ "^(Scanning dependencies of target)(.*)$",
           performing, "normal,bold" ],
-        # Link
+        # Link (make)
         [ "^(Linking .* )(library|executable) (.*/)*(.+(\.[aso]+)*)$",
           untimed, "normal,normal,bold" ],
+        # Link (ninja)
+        [ "^\[[0-9/]+\]\s?(Linking .* )(library|executable) (.*/)*(.+(\.[aso]+)*)$",
+          untimed, "normal,normal,bold" ],
         # [percent] Built
-        [ "^\[\s*[0-9]+%\]\s(Built target)(\s.*)$",
+        [ "^\[\s*[0-9/]+%?\]\s(Built target)(\s.*)$",
           performed, "normal,bold" ],
         # [percent] Building
-        [ "^\[\s*[0-9]+%\]\s(Building \w* object)(\s+.*/)([-\w]+.c.*)(.o)$",
+        [ "^\[\s*[0-9/]+%?\]\s(Building \w* object)(\s+.*/)([-\w]+.c.*)(.o)$",
             performing, "normal,normal,bold,normal"],
         # [percent] Generating
-        [ "^\[\s*[0-9]+%\]\s(Generating)(\s+.*)$",
+        [ "^\[\s*[0-9/]+%?\]\s(Generating)(\s+.*)$",
             performing, "normal,bold"],
         # make errors
         [ "make\[[0-9]+\].*", "yellow"],
         [ "(make: \*\*\* \[.+\] )(.* [0-9]+)", "red", "normal,bold"],
-        # progress percentage
-        [ "^(\[\s*[0-9]+%\])","Scale" ]
+        # progress percentage (make)
+        [ "^(\[\s*[0-9]+%\])","Scale" ],
+        # progress percentage (ninja)
+        [ "^(\[[0-9]+/[0-9]+\])","Fraction" ]
     ]


### PR DESCRIPTION
When using ninja generator, lines are a bit different from make:

```
[2/89] Building CXX object CMakeFiles/qi.dir/src/path.cpp.o
```

I made some changes to do the same coloring than make
