### PR TITLE
replace elipses with three periods

### DIFF
--- a/colout/colout.py
+++ b/colout/colout.py
@@ -776,7 +776,7 @@ def _args_parse(argv, usage=""):
 
     parser.add_argument("color", metavar="COLOR", type=str, nargs='?',
             default="red",
-            help="A number in [0…255], a color name, a colormap name, \
+            help="A number in [0...255], a color name, a colormap name, \
             a palette or a comma-separated list of those values." + pygments_warn)
 
     parser.add_argument("style", metavar="STYLE", type=str, nargs='?',


### PR DESCRIPTION
elipses was causing exceptions when trying to print
the help message:
  UnicodeEncodeError: 'latin-1' codec can't encode
  character '\u2026' in position 345: ordinal not in range(256)
Replaced them with three periods so folks can get help messages