### PR TITLE
Fixes #88: failed to install with pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
     scripts=['bin/colout'],
     include_package_data=True,
     install_requires=requires,
-    license=open('LICENSE').read(),
+    license='GPLv3',
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@
 import os
 import sys
 
-import colout
-
 try:
     from setuptools import setup
 except ImportError:
@@ -20,14 +18,14 @@ requires = ['argparse', 'pygments', 'babel']
 
 setup(
     name='colout',
-    version='0.1',
+    version='0.5',
     description='Color Up Arbitrary Command Output.',
     long_description=open('README.md').read(),
     author='nojhan',
     author_email='nojhan@nojhan.net',
     url='http://nojhan.github.com/colout/',
     packages=packages,
-    package_data={'': ['LICENSE']},
+    package_data={'': ['LICENSE', 'README.md']},
     package_dir={'colout': 'colout'},
     scripts=['bin/colout'],
     include_package_data=True,


### PR DESCRIPTION
Also this fix includes package version issue, fixed in #87.

In order to generate python package with all the files in it, use this command:

    python setup.py sdist