### PR TITLE
fix g++ coloration

### DIFF
--- a/colout/colout_g++.py
+++ b/colout/colout_g++.py
@@ -36,15 +36,16 @@ def theme(context):
     return context,[
         # Command line
         [ "[/\s]([cg]\+\+-*[0-9]*\.*[0-9]*)", "white", "bold" ],
-        [ "\s(\-D)(\s*[^\s]+\s)", "none,green", "normal,bold" ],
-        [ "\s-g\s", "green", "normal" ],
-        [ "\s-O[0-4]*\s", "green", "normal" ],
+        [ "\s(\-D)(\s*[^\s]+)", "none,green", "normal,bold" ],
+        [ "\s(-g)", "green", "normal" ],
+        [ "\s-O[0-4]", "green", "normal" ],
         [ "\s-[Wf][^\s]*", "magenta", "normal" ],
+        [ "\s-pedantic", "magenta", "normal" ],
         [ "\s(-I)(/*[^\s]+/)([^/\s]+)", "none,blue", "normal,normal,bold" ],
         [ "\s(-L)(/*[^\s]+/)([^/\s]+)", "none,cyan", "normal,normal,bold" ],
         [ "\s(-l)([^/\s]+)", "none,cyan", "normal,bold" ],
         [ "\s-[oc]", "red", "bold" ],
-        [ "\s(-+std)=*([^s]+)", "red", "normal,bold" ],
+        [ "\s(-+std(?:lib)?)=?([^\s]+)", "red", "normal,bold" ],
 
         # Important messages
         [ _("error: "), "red", "bold" ],


### PR DESCRIPTION
This fixes a few coloration bugs where one every other option is colorated because the regex would match the final space and the next regex would try to match the first space, for example in ` -Dsomething -Dotherthing`. There are also a few other small fixes.