### PR TITLE
Release improvements/fixes

### DIFF
--- a/colout/colout.py
+++ b/colout/colout.py
@@ -18,7 +18,6 @@ import string
 import hashlib
 import functools
 import argparse
-import six
 
 # set the SIGPIPE handler to kill the program instead of
 # ending in a write error when a broken pipe occurs
@@ -28,6 +27,8 @@ signal.signal( signal.SIGPIPE, signal.SIG_DFL )
 ###############################################################################
 # Global variable(s)
 ###############################################################################
+
+PY2 = sys.version_info.major == 2
 
 context = {}
 debug = False
@@ -699,7 +700,7 @@ def write(colored, stream = sys.stdout):
     """
     Write "colored" on sys.stdout, then flush.
     """
-    if six.PY2: # If Python 2.x: force unicode
+    if PY2: # If Python 2.x: force unicode
         if isinstance(colored, unicode):
             colored = colored.encode('utf-8')
     try:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.argv[-1] == 'publish':
 
 packages = ['colout']
 
-requires = ['argparse', 'pygments', 'babel']
+requires = ['argparse; python_version < "2.7"', 'pygments', 'babel']
 
 setup(
     name='colout',


### PR DESCRIPTION
This drops the use of six:
 * wasn't listed in the dependencies so would have broke clean installs (e.g. installed via [pipsi](https://github.com/mitsuhiko/pipsi))
 * only one constant was used so replaced it with the equivilant

It also stops trying to install argparse on python versions >= 2.7.

Could this be released with `python setup.py bdist_wheel --universal upload` so the package is a 2/3 compatible wheel? I tested the change on [https://test.pypi.org/](https://test.pypi.org/simple/colout/) and it installed through `PIP_INDEX_URL=https://test.pypi.org/simple/ pip install --user colout`.

It still isn't working in pipsi, so I will keep looking, but those changes may be a separate PR.