### PR TITLE
prevent No such file or directory: 'README.md' on install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     name='colout',
     version='0.6',
     description='Color Up Arbitrary Command Output.',
-    long_description=open('README.md').read(),
+    long_description=open(os.path.join(os.path.dirname(__file__), 'README.md')).read(),
     author='nojhan',
     author_email='nojhan@nojhan.net',
     url='http://nojhan.github.com/colout/',


### PR DESCRIPTION
This should prevent the following error,

```
$ pip --version
pip 18.1 from /Users/jq/.pyenv/versions/3.6.5/envs/jupyter/lib/python3.6/site-packages/pip (python 3.6)
$ pip install colout
Collecting colout
  Downloading https://files.pythonhosted.org/packages/3d/ba/3ef31c0df3ace69271cc8b1af6b529f24de66ff42c0d99a8d18aa980a307/colout-0.5.tar.gz (47kB)
    100% |████████████████████████████████| 51kB 970kB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/0x/y8s2qlk558596kyqdhv3nwv40000gn/T/pip-install-gixoekff/colout/setup.py", line 25, in <module>
        long_description=open('README.md').read(),
    FileNotFoundError: [Errno 2] No such file or directory: 'README.md'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/0x/y8s2qlk558596kyqdhv3nwv40000gn/T/pip-install-gixoekff/colout/
```

I tested this locally, by clone of this repository, change to folder parent of the repository,
install from relative folder, `./colout`, where `README.md` is not found:

```
$ pip install --upgrade --force-reinstall ./colout/
```

Without patch, fails, with patch, succeeds.