### PR TITLE
Update colout.py to remove PY2 global

### DIFF
--- a/colout/colout.py
+++ b/colout/colout.py
@@ -30,8 +30,6 @@ signal.signal( signal.SIGPIPE, signal.SIG_DFL )
 # Global variable(s)
 ###############################################################################
 
-PY2 = sys.version_info.major == 2
-
 context = {}
 debug = False
 
@@ -757,9 +755,6 @@ def write(colored, stream = sys.stdout):
     """
     Write "colored" on sys.stdout, then flush.
     """
-    if PY2: # If Python 2.x: force unicode
-        if isinstance(colored, unicode):
-            colored = colored.encode('utf-8')
     try:
         stream.write(colored)
         stream.flush()


### PR DESCRIPTION
Python 2 will retire in thirteen days (see https://pythonclock.org/), there is no reason to keep obsolete checks in the code any longer.