### PR TITLE
Add theme for AMD/Xilinx Vivado tool

### DIFF
--- a/colout/colout_vivado.py
+++ b/colout/colout_vivado.py
@@ -1,0 +1,24 @@
+
+def theme(context):
+    # Theme for coloring AMD/Xilinx Vivado IDE synthesis and implementation output
+    return context,[
+        [ "^#.+", "green" ],
+        [ "^.+ Checksum: .+$", "green" ],
+
+        [ "^.+Time \(s\).+", "green" ],
+        [ "^Time \(s\).+", "green" ],
+
+        [ "Estimated Timing Summary \|.+\|.+\|", "cyan", "bold" ],
+        [ "Intermediate Timing Summary \|.+\|.+\|", "cyan", "bold" ],
+
+        [ "^INFO:", "white", "bold" ],
+        [ "^WARNING:.+$", "yellow" ],
+        [ "^CRITICAL WARNING:.+$", "red" ],
+        [ "^ERROR:.+$", "red" ],
+
+        [ "^Phase [0-9]+.[0-9]+.[0-9]+.[0-9]+.+$", "magenta", "bold" ],
+        [ "^Phase [0-9]+.[0-9]+.[0-9]+.+$",        "magenta", "bold" ],
+        [ "^Phase [0-9]+.[0-9]+.+$",               "magenta", "bold" ],
+        [ "^Phase [0-9]+.+$",                      "magenta", "bold" ]
+    ]
+

--- a/colout/colout_vivado.py
+++ b/colout/colout_vivado.py
@@ -2,7 +2,9 @@
 def theme(context):
     # Theme for coloring AMD/Xilinx Vivado IDE synthesis and implementation output
     return context,[
+        [ "^\s*\*+.+$", "green" ],
         [ "^#.+", "green" ],
+
         [ "^.+ Checksum: .+$", "green" ],
 
         [ "^.+Time \(s\).+", "green" ],


### PR DESCRIPTION
Hi!
This is a theme for coloring Vivado output. Vivado is an IDE for developing for FPGA's.
https://www.xilinx.com/products/design-tools/vivado.html

Please consider a merge 