### PR TITLE
add target-groups option

### DIFF
--- a/colout/colout.py
+++ b/colout/colout.py
@@ -699,7 +699,10 @@ def colorup(text, pattern, color="red", style="normal", on_groups=False, sep_lis
             colored_text += partial
 
         else:
-            nb_groups = len(match.groups())
+            if (target_groups == None):
+                nb_groups = len(match.groups())
+            else:
+                nb_groups = len(target_groups)
 
             # Build a list of colors that match the number of grouped,
             # if there is not enough colors, duplicate the last one.
@@ -723,10 +726,10 @@ def colorup(text, pattern, color="red", style="normal", on_groups=False, sep_lis
             if (target_groups == None):
                 target_groups = range(1, nb_groups+1)
 
-            for group in target_groups:
+            for index, group in enumerate(target_groups):
                 # If a group didn't match, there's nothing to color
                 if match.group(group) is not None:
-                    partial, end = colorout(text, match, end, group_colors[group-1], group_styles[group-1], group)
+                    partial, end = colorout(text, match, end, group_colors[index], group_styles[index], group)
                     colored_text += partial
 
     # Append the remaining part of the text, if any.


### PR DESCRIPTION
The idea here is to let the user specify which groups should be matched for the purposes of colouring. If unspecified, then use the existing behaviour (i.e., iterate through all groups).

This addresses several problems:
* Sometimes groups are only in the regex for the purpose of pattern matching, not colouring;
* Nested groups will repeat part of the string in the output;
* Regex using `+` or `*` after a group will only capture the last instance of the group, so to capture the whole thing, the group must be nested inside another.

The code works, but I don't really know Python at all so I ended up just making `target-groups` a global variable. This is presumably not the right way to do it, but it should be easy to fix for someone who knows better.

# Example:

```
# BEFORE:

$ echo 'a1 b2 c3 123-456-7890 9z 8q 7w hello' | ./colout.py '([a-z]\d )+(\d+-)*\d+ (\d[a-z] )*(\w+)' blue,yellow,none,red
Highlights only 'c3' instead of 'a1 b2 c3', etc.

$ echo 'a1 b2 c3 123-456-7890 9z 8q 7w hello' | ./colout.py '(([a-z]\d )+)((\d+-)*\d+) ((\d[a-z] )*)(\w+)' blue,yellow,none,red
This is an attempt to address the first problem by wrapping in another layer of groups; however, it produces garbled output, and the colours are wrong because they cycle through unwanted groups.

# PROPOSED SOLUTION:

$ echo 'a1 b2 c3 123-456-7890 9z 8q 7w hello' | ./colout.py '(([a-z]\d )+)((\d+-)*\d+) ((\d[a-z] )*)(\w+)' blue,yellow,red -tg 1 3 7
We get the expected output by specifying the groups we want. Also note that the colour 'none' is no longer necessary, since we can just omit that group from the list.
```